### PR TITLE
remove build-time entitlement for host network access

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,7 +30,6 @@ services:
     build:
       context: .
       dockerfile: Dockerfile-server-mcp
-      network: host
     command: ["python", "-m", "server.fastmcp_proxy"]
     stdin_open: true
     tty: true


### PR DESCRIPTION
Removes the `network: host` build-time entitlement. Docker daemon configurations may often not allow this, giving the user an error such as:

`failed to solve: granting entitlement network.host is not allowed by build daemon configuration`  

As far as I can tell, this is not needed at build time, and we already have the runtime entitlement with `network_mode: host` which should suffice for the proxy.