### PR TITLE
Fixed rating_scale string/int behaviour

### DIFF
--- a/src/ui/js/Pages/Workspaces/FlyoutForm.js
+++ b/src/ui/js/Pages/Workspaces/FlyoutForm.js
@@ -175,7 +175,7 @@ const FlyoutForm = ({
             onChange={(e) => {
               setForm(prev => ({
                 ...prev, rating_scale: {
-                  ...prev.rating_scale, min: e.target.value
+                  ...prev.rating_scale, min: parseInt(e.target.value, 10)
                 }
               }))
             }}
@@ -195,7 +195,7 @@ const FlyoutForm = ({
             onChange={(e) => {
               setForm(prev => ({
                 ...prev, rating_scale: {
-                  ...prev.rating_scale, max: e.target.value
+                  ...prev.rating_scale, max: parseInt(e.target.value, 10)
                 }
               }))
             }}


### PR DESCRIPTION
added casting to min/max value for the rating scale to prevent a TypeError. This happens whenever someone changes from the default rating scale values (or at least it did for me).