### PR TITLE
Fix d3-color ReDoS vulnerability (GHSA-36jr-mh4h-2g58)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "relevance-studio",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "relevance-studio",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "license": "Elastic License 2.0",
       "dependencies": {
         "@babel/polyfill": "^7.12.1",
@@ -5711,11 +5711,6 @@
       "dependencies": {
         "internmap": "^1.0.0"
       }
-    },
-    "node_modules/d3-scale/node_modules/d3-color": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-2.0.0.tgz",
-      "integrity": "sha512-SPXi0TSKPD4g9tw0NMZFnR95XVgUZiBH+uUTqQuDu1OsE2zomHU7ho0FISciaPvosimixwHFl3WHLGabv6dDgQ=="
     },
     "node_modules/d3-scale/node_modules/d3-interpolate": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,9 @@
     "dev": "webpack-dev-server --mode=development",
     "test:ui": "jest --config jest.config.js"
   },
+  "overrides": {
+    "d3-color": ">=3.1.0"
+  },
   "devDependencies": {
     "@babel/cli": "^7.27.2",
     "@babel/core": "^7.27.1",


### PR DESCRIPTION
## Summary
- Adds npm `overrides` to force `d3-color>=3.1.0` across all transitive deps
- Fixes HIGH severity ReDoS vulnerability in `d3-color@2.0.0`
- Root cause: `@elastic/charts` pins `d3-scale@^3.3.0` which caps `d3-interpolate` at v2, pulling in vulnerable `d3-color@2.0.0`. No upstream fix available — latest `@elastic/charts@71.4.1` still has this pinning.
- The `>=3.1.0` override is future-safe and becomes a no-op once upstream bumps to `d3-scale@4`

## Test plan
- [x] `npm ls d3-color` confirms both copies resolve to 3.1.0
- [x] `npm audit` no longer flags d3-color
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)