### PR TITLE
Add source_includes to MCP get tools for field-level filtering

### DIFF
--- a/src/server/api/benchmarks.py
+++ b/src/server/api/benchmarks.py
@@ -60,21 +60,21 @@ def tags(workspace_id: str, es_client: Optional["Elasticsearch"] = None) -> Dict
     es_response = utils.search_tags("benchmarks", workspace_id, es_client=es_client)
     return es_response
 
-def get(_id: str, es_client: Optional["Elasticsearch"] = None) -> Dict[str, Any]:
+def get(_id: str, source_includes: Optional[List[str]] = None, es_client: Optional["Elasticsearch"] = None) -> Dict[str, Any]:
     """Get a benchmark by its _id.
 
     Args:
         _id: The UUID of the benchmark.
+        source_includes: Optional list of source fields to return (e.g. ["name", "task"]).
 
     Returns:
         The benchmark document from Elasticsearch.
     """
     client = es_client if es_client is not None else es("studio")
-    es_response = client.get(
-        index=INDEX_NAME,
-        id=_id,
-        source_excludes="_search",
-    )
+    kwargs = dict(index=INDEX_NAME, id=_id, source_excludes="_search")
+    if source_includes is not None:
+        kwargs["source_includes"] = source_includes
+    es_response = client.get(**kwargs)
     return es_response
 
 def create(doc: Dict[str, Any], _id: str = None, user: str = None, via: str = None, es_client: Optional["Elasticsearch"] = None) -> Dict[str, Any]:

--- a/src/server/api/conversations.py
+++ b/src/server/api/conversations.py
@@ -65,21 +65,26 @@ def search(
     )
     return response
 
-def get(_id: str, user: Optional[str] = None, es_client: Optional["Elasticsearch"] = None) -> Dict[str, Any]:
+def get(_id: str, user: Optional[str] = None, source_includes: Optional[List[str]] = None, es_client: Optional["Elasticsearch"] = None) -> Dict[str, Any]:
     """Get a conversation by its _id.
 
     Args:
         _id: The UUID of the conversation.
+        source_includes: Optional list of source fields to return (e.g. ["messages"]).
 
     Returns:
         The conversation document from Elasticsearch.
     """
     client = es_client if es_client is not None else es("studio")
-    es_response = client.get(
-        index=INDEX_NAME,
-        id=_id,
-        source_excludes="_search",
-    )
+    # Ensure ownership field is always fetched for the access check
+    includes = source_includes
+    if includes is not None and user is not None:
+        if "@meta.created_by" not in includes:
+            includes = list(includes) + ["@meta.created_by"]
+    kwargs = dict(index=INDEX_NAME, id=_id, source_excludes="_search")
+    if includes is not None:
+        kwargs["source_includes"] = includes
+    es_response = client.get(**kwargs)
     _assert_owner(es_response, user)
     return es_response
 

--- a/src/server/api/displays.py
+++ b/src/server/api/displays.py
@@ -46,21 +46,21 @@ def search(
     )
     return response
 
-def get(_id: str, es_client: Optional["Elasticsearch"] = None) -> Dict[str, Any]:
+def get(_id: str, source_includes: Optional[List[str]] = None, es_client: Optional["Elasticsearch"] = None) -> Dict[str, Any]:
     """Get a display by its _id.
 
     Args:
         _id: The UUID of the display.
+        source_includes: Optional list of source fields to return (e.g. ["index_pattern", "template"]).
 
     Returns:
         The display document from Elasticsearch.
     """
     client = es_client if es_client is not None else es("studio")
-    es_response = client.get(
-        index=INDEX_NAME,
-        id=_id,
-        source_excludes="_search",
-    )
+    kwargs = dict(index=INDEX_NAME, id=_id, source_excludes="_search")
+    if source_includes is not None:
+        kwargs["source_includes"] = source_includes
+    es_response = client.get(**kwargs)
     return es_response
 
 def create(doc: Dict[str, Any], _id: str = None, user: str = None, via: str = None, es_client: Optional["Elasticsearch"] = None) -> Dict[str, Any]:

--- a/src/server/api/evaluations.py
+++ b/src/server/api/evaluations.py
@@ -796,21 +796,21 @@ def search(
     )
     return response
 
-def get(_id: str, es_client: Optional["Elasticsearch"] = None) -> Dict[str, Any]:
+def get(_id: str, source_includes: Optional[List[str]] = None, es_client: Optional["Elasticsearch"] = None) -> Dict[str, Any]:
     """Get an evaluation by its _id.
 
     Args:
         _id: The UUID of the evaluation.
+        source_includes: Optional list of source fields to return (e.g. ["summary", "took"]).
 
     Returns:
         The evaluation document from Elasticsearch.
     """
     client = es_client if es_client is not None else es("studio")
-    es_response = client.get(
-        index=INDEX_NAME,
-        id=_id,
-        source_excludes="_search",
-    )
+    kwargs = dict(index=INDEX_NAME, id=_id, source_excludes="_search")
+    if source_includes is not None:
+        kwargs["source_includes"] = source_includes
+    es_response = client.get(**kwargs)
     return es_response
 
 def create(

--- a/src/server/api/scenarios.py
+++ b/src/server/api/scenarios.py
@@ -59,21 +59,21 @@ def tags(workspace_id: str, es_client: Optional["Elasticsearch"] = None) -> Dict
     es_response = utils.search_tags("scenarios", workspace_id, es_client=es_client)
     return es_response
 
-def get(_id: str, es_client: Optional["Elasticsearch"] = None) -> Dict[str, Any]:
+def get(_id: str, source_includes: Optional[List[str]] = None, es_client: Optional["Elasticsearch"] = None) -> Dict[str, Any]:
     """Get a scenario by its _id.
 
     Args:
         _id: The UUID of the scenario.
+        source_includes: Optional list of source fields to return (e.g. ["name", "values"]).
 
     Returns:
         The scenario document from Elasticsearch.
     """
     client = es_client if es_client is not None else es("studio")
-    es_response = client.get(
-        index=INDEX_NAME,
-        id=_id,
-        source_excludes="_search",
-    )
+    kwargs = dict(index=INDEX_NAME, id=_id, source_excludes="_search")
+    if source_includes is not None:
+        kwargs["source_includes"] = source_includes
+    es_response = client.get(**kwargs)
     return es_response
 
 def create(doc: Dict[str, Any], user: str = None, via: str = None, es_client: Optional["Elasticsearch"] = None) -> Dict[str, Any]:

--- a/src/server/api/strategies.py
+++ b/src/server/api/strategies.py
@@ -58,21 +58,21 @@ def tags(workspace_id: str, es_client: Optional["Elasticsearch"] = None) -> Dict
     es_response = utils.search_tags("strategies", workspace_id, es_client=es_client)
     return es_response
 
-def get(_id: str, es_client: Optional["Elasticsearch"] = None) -> Dict[str, Any]:
+def get(_id: str, source_includes: Optional[List[str]] = None, es_client: Optional["Elasticsearch"] = None) -> Dict[str, Any]:
     """Get a strategy by its _id.
 
     Args:
         _id: The UUID of the strategy.
+        source_includes: Optional list of source fields to return (e.g. ["name", "template"]).
 
     Returns:
         The strategy document from Elasticsearch.
     """
     client = es_client if es_client is not None else es("studio")
-    es_response = client.get(
-        index=INDEX_NAME,
-        id=_id,
-        source_excludes="_search",
-    )
+    kwargs = dict(index=INDEX_NAME, id=_id, source_excludes="_search")
+    if source_includes is not None:
+        kwargs["source_includes"] = source_includes
+    es_response = client.get(**kwargs)
     return es_response
 
 def create(doc: Dict[str, Any], _id: str = None, user: str = None, via: str = None, es_client: Optional["Elasticsearch"] = None) -> Dict[str, Any]:

--- a/src/server/api/workspaces.py
+++ b/src/server/api/workspaces.py
@@ -54,21 +54,21 @@ def tags(es_client: Optional["Elasticsearch"] = None) -> Dict[str, Any]:
     es_response = utils.search_tags("workspaces", es_client=es_client)
     return es_response
 
-def get(_id: str, es_client: Optional["Elasticsearch"] = None) -> Dict[str, Any]:
+def get(_id: str, source_includes: Optional[List[str]] = None, es_client: Optional["Elasticsearch"] = None) -> Dict[str, Any]:
     """Get a workspace by its _id.
 
     Args:
         _id: The UUID of the workspace.
+        source_includes: Optional list of source fields to return (e.g. ["name", "params"]).
 
     Returns:
         The workspace document from Elasticsearch.
     """
     client = es_client if es_client is not None else es("studio")
-    es_response = client.get(
-        index=INDEX_NAME,
-        id=_id,
-        source_excludes="_search",
-    )
+    kwargs = dict(index=INDEX_NAME, id=_id, source_excludes="_search")
+    if source_includes is not None:
+        kwargs["source_includes"] = source_includes
+    es_response = client.get(**kwargs)
     return es_response
 
 def create(doc: Dict[str, Any], _id: str = None, user: str = None, via: str = None, es_client: Optional["Elasticsearch"] = None) -> Dict[str, Any]:

--- a/src/server/fastmcp.py
+++ b/src/server/fastmcp.py
@@ -53,9 +53,9 @@ def conversations_search(
     return dict(api.conversations.search(text, filters, sort, size, page, aggs, user=user, es_client=es_client))
 
 @mcp.tool(description=api.conversations.get.__doc__)
-def conversations_get(ctx: Context, _id: str) -> Dict[str, Any]:
+def conversations_get(ctx: Context, _id: str, source_includes: Optional[List[str]] = None) -> Dict[str, Any]:
     user, es_client = mcp_auth.get_mcp_auth_from_context(ctx)
-    return dict(api.conversations.get(_id, user=user, es_client=es_client))
+    return dict(api.conversations.get(_id, user=user, source_includes=source_includes, es_client=es_client))
 
 @mcp.tool(description=api.conversations.create.__doc__ + f"""\n
 JSON schema for doc:\n\n{ConversationsCreate.model_input_json_schema()}
@@ -93,9 +93,9 @@ def workspaces_search(
     return dict(api.workspaces.search(text, filters, sort, size, page, aggs, es_client=es_client))
 
 @mcp.tool(description=api.workspaces.get.__doc__)
-def workspaces_get(ctx: Context, _id: str) -> Dict[str, Any]:
+def workspaces_get(ctx: Context, _id: str, source_includes: Optional[List[str]] = None) -> Dict[str, Any]:
     user, es_client = mcp_auth.get_mcp_auth_from_context(ctx)
-    return dict(api.workspaces.get(_id, es_client=es_client))
+    return dict(api.workspaces.get(_id, source_includes=source_includes, es_client=es_client))
 
 @mcp.tool(description=api.workspaces.create.__doc__ + f"""\n
 JSON schema for doc:\n\n{WorkspaceCreate.model_input_json_schema()}
@@ -134,9 +134,9 @@ def displays_search(
     return dict(api.displays.search(workspace_id, text, filters, sort, size, page, aggs, es_client=es_client))
 
 @mcp.tool(description=api.displays.get.__doc__)
-def displays_get(ctx: Context, _id: str) -> Dict[str, Any]:
+def displays_get(ctx: Context, _id: str, source_includes: Optional[List[str]] = None) -> Dict[str, Any]:
     user, es_client = mcp_auth.get_mcp_auth_from_context(ctx)
-    return dict(api.displays.get(_id, es_client=es_client))
+    return dict(api.displays.get(_id, source_includes=source_includes, es_client=es_client))
 
 @mcp.tool(description=api.displays.create.__doc__ + f"""\n
 JSON schema for doc:\n\n{DisplayCreate.model_input_json_schema()}
@@ -180,9 +180,9 @@ def scenarios_tags(ctx: Context, workspace_id: str) -> Dict[str, Any]:
     return dict(api.scenarios.tags(workspace_id, es_client=es_client))
 
 @mcp.tool(description=api.scenarios.get.__doc__)
-def scenarios_get(ctx: Context, _id: str) -> Dict[str, Any]:
+def scenarios_get(ctx: Context, _id: str, source_includes: Optional[List[str]] = None) -> Dict[str, Any]:
     user, es_client = mcp_auth.get_mcp_auth_from_context(ctx)
-    return dict(api.scenarios.get(_id, es_client=es_client))
+    return dict(api.scenarios.get(_id, source_includes=source_includes, es_client=es_client))
 
 @mcp.tool(description=api.scenarios.create.__doc__ + f"""\n
 JSON schema for doc:\n\n{ScenarioCreate.model_input_json_schema()}
@@ -254,9 +254,9 @@ def strategies_tags(ctx: Context, workspace_id: str) -> Dict[str, Any]:
     return dict(api.strategies.tags(workspace_id, es_client=es_client))
 
 @mcp.tool(description=api.strategies.get.__doc__)
-def strategies_get(ctx: Context, _id: str) -> Dict[str, Any]:
+def strategies_get(ctx: Context, _id: str, source_includes: Optional[List[str]] = None) -> Dict[str, Any]:
     user, es_client = mcp_auth.get_mcp_auth_from_context(ctx)
-    return dict(api.strategies.get(_id, es_client=es_client))
+    return dict(api.strategies.get(_id, source_includes=source_includes, es_client=es_client))
 
 @mcp.tool(description=api.strategies.create.__doc__ + f"""\n
 JSON schema for doc:\n\n{StrategyCreate.model_input_json_schema()}
@@ -305,9 +305,9 @@ def benchmarks_make_candidate_pool(ctx: Context, workspace_id: str, task: Dict[s
     return dict(api.benchmarks.make_candidate_pool(workspace_id, task, es_client=es_client))
 
 @mcp.tool(description=api.benchmarks.get.__doc__)
-def benchmarks_get(ctx: Context, _id: str) -> Dict[str, Any]:
+def benchmarks_get(ctx: Context, _id: str, source_includes: Optional[List[str]] = None) -> Dict[str, Any]:
     user, es_client = mcp_auth.get_mcp_auth_from_context(ctx)
-    return dict(api.benchmarks.get(_id, es_client=es_client))
+    return dict(api.benchmarks.get(_id, source_includes=source_includes, es_client=es_client))
 
 @mcp.tool(description=api.benchmarks.create.__doc__ + f"""\n
 JSON schema for doc:\n\n{BenchmarkCreate.model_input_json_schema()}
@@ -347,9 +347,9 @@ def evaluations_search(
     return dict(api.evaluations.search(workspace_id, benchmark_id, text, filters, sort, size, page, aggs, es_client=es_client))
 
 @mcp.tool(description=api.evaluations.get.__doc__)
-def evaluations_get(ctx: Context, _id: str) -> Dict[str, Any]:
+def evaluations_get(ctx: Context, _id: str, source_includes: Optional[List[str]] = None) -> Dict[str, Any]:
     user, es_client = mcp_auth.get_mcp_auth_from_context(ctx)
-    return dict(api.evaluations.get(_id, es_client=es_client))
+    return dict(api.evaluations.get(_id, source_includes=source_includes, es_client=es_client))
 
 @mcp.tool(description=api.evaluations.create.__doc__ + f"""\n
 JSON schema for doc:\n\n{EvaluationCreate.model_input_json_schema()}

--- a/tests/unit/test_api_es_client.py
+++ b/tests/unit/test_api_es_client.py
@@ -84,6 +84,32 @@ class TestDisplaysEsClientFallback:
         assert client.calls[0][1]["id"] == "some-id"
 
 
+class TestSourceIncludes:
+    """Test that get() passes source_includes to ES when provided."""
+
+    def test_workspaces_get_passes_source_includes(self, monkeypatch):
+        client = _MockSearchClient()
+        monkeypatch.setattr(workspaces, "es", lambda name: pytest.fail("es() should not be called"))
+        workspaces.get("some-id", source_includes=["name", "params"], es_client=client)
+        assert len(client.calls) == 1
+        assert client.calls[0][1]["source_includes"] == ["name", "params"]
+        assert client.calls[0][1]["source_excludes"] == "_search"
+
+    def test_workspaces_get_omits_source_includes_when_none(self, monkeypatch):
+        client = _MockSearchClient()
+        monkeypatch.setattr(workspaces, "es", lambda name: pytest.fail("es() should not be called"))
+        workspaces.get("some-id", es_client=client)
+        assert len(client.calls) == 1
+        assert "source_includes" not in client.calls[0][1]
+
+    def test_displays_get_passes_source_includes(self, monkeypatch):
+        client = _MockSearchClient()
+        monkeypatch.setattr(displays, "es", lambda name: pytest.fail("es() should not be called"))
+        displays.get("some-id", source_includes=["index_pattern"], es_client=client)
+        assert client.calls[0][1]["source_includes"] == ["index_pattern"]
+        assert client.calls[0][1]["source_excludes"] == "_search"
+
+
 class TestContentEsClientFallback:
     """Test that content API uses es_client when provided, else es('content')."""
 

--- a/tests/unit/test_conversations_owner_visibility.py
+++ b/tests/unit/test_conversations_owner_visibility.py
@@ -67,6 +67,21 @@ def test_delete_forbidden_when_owner_differs():
     assert client.delete_called is False
 
 
+def test_get_with_source_includes_still_checks_owner():
+    """source_includes auto-adds @meta.created_by so ownership check works."""
+    client = MockEsClient(owner="bob")
+
+    with pytest.raises(Forbidden):
+        conversations.get("conv-1", user="alice", source_includes=["messages"], es_client=client)
+
+
+def test_get_with_source_includes_returns_when_owner_matches():
+    client = MockEsClient(owner="alice")
+
+    result = conversations.get("conv-1", user="alice", source_includes=["messages"], es_client=client)
+    assert result["_source"]["@meta"]["created_by"] == "alice"
+
+
 def test_flask_conversation_get_returns_403_for_other_owner(monkeypatch):
     client = app.test_client()
     mock_es_client = MockEsClient(owner="alice")


### PR DESCRIPTION
## Summary
- Adds optional `source_includes` param to all 7 `*_get` MCP tools and their backing API functions, letting LLM consumers request only the fields they need (e.g. `evaluations_get(_id, source_includes=["summary"])`)
- Conversations `get` auto-injects `@meta.created_by` into `source_includes` so the ownership check can't be bypassed
- `source_excludes="_search"` is always preserved

## Test plan
- [x] 22 unit tests pass (5 new, 17 existing)
- [ ] Verify MCP tool schema exposes `source_includes` in Claude Desktop / Cursor
- [ ] Test `evaluations_get` with and without `source_includes` against a live deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)